### PR TITLE
Run CI tests against .NET 4.6.2 as well

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Build solution
       run: dotnet build UrlBase64/UrlBase64.csproj -p:Configuration=Release -p:TargetFrameworks="${{ matrix.dotnet.tfm }}" -p:LangVersion="latest" --verbosity normal
     - name: Run tests
-      if: ${{ ! matrix.dotnet.tfm == 'net20' }}
+      if: matrix.dotnet.tfm != 'net20'
       run: dotnet test -p:Configuration=Release --verbosity normal -p:TargetFrameworks="${{ matrix.dotnet.tfm }}" -p:LangVersion="latest"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,27 +15,27 @@ jobs:
       matrix:
         dotnet: [
           { os: 'windows', version: '2', tfm: 'net20' },
-          { os: 'windows', version: '4', tfm: 'net40' },
-          { os: 'ubuntu',  version: '6', tfm: 'net6.0' },
+          { os: 'windows', version: '4', tfm: 'net462' },
+          { os: 'ubuntu',  version: '3', tfm: 'net3.1' },
           { os: 'ubuntu',  version: '8', tfm: 'net8.0' },
       ]
 
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
-      if: endsWith(matrix.dotnet.tfm, '.0') # only for .NET core
+      if: contains(matrix.dotnet.tfm, '.') # only for .NET core
       uses: actions/setup-dotnet@v4
       id: stepid
       with:
         dotnet-version: ${{ matrix.dotnet.version }}
       # Without global.json, tests will be executed under the latest installed version!
     - name: Create temporary global.json
-      if: endsWith(matrix.dotnet.tfm, '.0') # only for .NET core
+      if: contains(matrix.dotnet.tfm, '.') # only for .NET core
       run: echo '{"sdk":{"version":"${{steps.stepid.outputs.dotnet-version}}"}}' > ./global.json
     - name: Restore packages
       run: dotnet restore UrlBase64/UrlBase64.csproj -p:Configuration=Release -p:TargetFrameworks="${{ matrix.dotnet.tfm }}" -p:LangVersion="latest" --verbosity normal
     - name: Build solution
       run: dotnet build UrlBase64/UrlBase64.csproj -p:Configuration=Release -p:TargetFrameworks="${{ matrix.dotnet.tfm }}" -p:LangVersion="latest" --verbosity normal
     - name: Run tests
-      if: endsWith(matrix.dotnet.tfm, '.0') # only for .NET core
+      if: ${{ ! matrix.dotnet.tfm == 'net20' }}
       run: dotnet test -p:Configuration=Release --verbosity normal -p:TargetFrameworks="${{ matrix.dotnet.tfm }}" -p:LangVersion="latest"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,8 +16,8 @@ jobs:
         dotnet: [
           { os: 'windows', version: '2', tfm: 'net20' },
           { os: 'windows', version: '4', tfm: 'net462' },
-          { os: 'ubuntu',  version: '3', tfm: 'net3.1' },
-          { os: 'ubuntu',  version: '8', tfm: 'net8.0' },
+          { os: 'ubuntu', version: '3.1', tfm: 'netcoreapp3.1' },
+          { os: 'ubuntu', version: '8', tfm: 'net8.0' },
       ]
 
     steps:

--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>disabled</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -1,6 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using NeoSmart.Utils;
+using System.IO;
 using System.Text;
 
 namespace Benchmark

--- a/UrlBase64/UrlBase64.csproj
+++ b/UrlBase64/UrlBase64.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net20;net40;netstandard2.0</TargetFrameworks>
@@ -57,7 +57,8 @@
     </None>
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard1.0' And '$(TargetFramework)' != 'net20' And '$(TargetFramework)' != 'net40'">
+  <!-- Under CI, TargetFramework is forced to net462 -->
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard1.0' And '$(TargetFramework)' != 'net20' And '$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net462'">
     <DefineConstants>$(DefineConstants);WITH_SPAN</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
This is the only version of .NET Framework supported by the MSTest dependencies for our test project.